### PR TITLE
Implement the international scholarships page

### DIFF
--- a/src/app/(app)/[lang]/international/education/page.tsx
+++ b/src/app/(app)/[lang]/international/education/page.tsx
@@ -26,9 +26,13 @@ export default async function EducationPage({
           </main>
 
           <LinksSidebar
-            description={text}
-            links={[
-              { href: EDUCATION_LINKS[action.link], label: action.label },
+            groups={[
+              {
+                description: text,
+                links: [
+                  { href: EDUCATION_LINKS[action.link], label: action.label },
+                ],
+              },
             ]}
           />
         </div>

--- a/src/app/(app)/[lang]/international/housing/page.tsx
+++ b/src/app/(app)/[lang]/international/housing/page.tsx
@@ -25,11 +25,15 @@ export default async function HousingPage({
           </main>
 
           <LinksSidebar
-            links={content.links.map((link) => ({
-              href: HOUSING_LINKS[link.link],
-              label: link.label,
-            }))}
-            title={content.important_links}
+            groups={[
+              {
+                links: content.links.map((link) => ({
+                  href: HOUSING_LINKS[link.link],
+                  label: link.label,
+                })),
+                title: content.important_links,
+              },
+            ]}
           />
         </div>
       </div>

--- a/src/app/(app)/[lang]/international/scholarships/components/ScholarshipsContent.tsx
+++ b/src/app/(app)/[lang]/international/scholarships/components/ScholarshipsContent.tsx
@@ -1,0 +1,37 @@
+import { ActionLink } from "@/components/common/ActionLink";
+import { ContentBlocks } from "@/components/common/ContentBlocks";
+import { SectionCard } from "@/components/common/SectionCard";
+
+import { SCHOLARSHIPS_LINKS } from "../scholarships.constants";
+import type { ScholarshipsSection } from "../scholarships.types";
+
+interface ScholarshipsContentProps {
+  sections: ScholarshipsSection[];
+}
+
+export function ScholarshipsContent({
+  sections,
+}: Readonly<ScholarshipsContentProps>) {
+  return (
+    <div className="flex flex-col gap-4 rounded-b-2xl border-x border-b border-[#e9e2d6] bg-[#fffefc] p-4 md:p-8">
+      {sections.map((section) => (
+        <SectionCard key={section.title} title={section.title}>
+          <div className="flex flex-col gap-2">
+            <ContentBlocks blocks={section.blocks} />
+
+            {section.actions?.map((action) => (
+              <ActionLink
+                className="w-fit"
+                href={SCHOLARSHIPS_LINKS[action.link]}
+                key={action.link}
+                label={action.label}
+              />
+            ))}
+          </div>
+        </SectionCard>
+      ))}
+    </div>
+  );
+}
+
+export default ScholarshipsContent;

--- a/src/app/(app)/[lang]/international/scholarships/loading.tsx
+++ b/src/app/(app)/[lang]/international/scholarships/loading.tsx
@@ -1,0 +1,15 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-[#f9f4f0]">
+      <div className="mx-auto w-full max-w-[1400px] animate-pulse px-4 py-8 md:px-8">
+        <div className="grid items-start xl:grid-cols-[minmax(0,1fr)_minmax(300px,343px)]">
+          <div>
+            <div className="h-56 rounded-t-2xl bg-ehk-dark-red/20" />
+            <div className="h-[840px] rounded-b-2xl border border-[#e9e2d6] bg-[#fffefc]" />
+          </div>
+          <div className="mt-4 h-[260px] rounded-2xl border border-[#e9e2d6] bg-[#fffefc] xl:mt-8 xl:rounded-l-none" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/[lang]/international/scholarships/page.tsx
+++ b/src/app/(app)/[lang]/international/scholarships/page.tsx
@@ -3,42 +3,44 @@ import { PageHeader } from "@/components/common/PageHeader";
 import { getDictionary } from "@/get-dictionary";
 import { i18n, type Locale } from "@/i18n-config";
 
-import { GettingStartedContent } from "./components/GettingStartedContent";
-import { GETTING_STARTED_LINKS } from "./gettingStarted.constants";
-import type { GettingStarted } from "./gettingStarted.types";
+import { ScholarshipsContent } from "./components/ScholarshipsContent";
+import { SCHOLARSHIPS_LINKS } from "./scholarships.constants";
+import type { Scholarships } from "./scholarships.types";
 
-export default async function GettingStartedPage({
+export default async function ScholarshipsPage({
   params,
 }: Readonly<{ params: Promise<{ lang: Locale }> }>) {
   const { lang } = await params;
   const locale = i18n.locales.includes(lang) ? lang : i18n.defaultLocale;
-  const dictionary = await getDictionary(
-    locale,
-    "international_getting_started"
-  );
+  const dictionary = await getDictionary(locale, "international_scholarships");
   const content = dictionary.international
-    .getting_started as unknown as GettingStarted;
+    .scholarships as unknown as Scholarships;
 
   return (
     <div className="min-h-screen bg-[#f9f4f0]">
       <div className="mx-auto w-full max-w-[1400px] px-4 py-8 md:px-8">
         <div className="grid items-start xl:grid-cols-[minmax(0,1fr)_minmax(300px,343px)]">
           <main className="min-w-0">
-            <PageHeader title={content.title} />
-            <GettingStartedContent
-              locale={locale}
-              sections={content.sections}
-            />
+            <PageHeader subtitle={content.intro} title={content.title} />
+            <ScholarshipsContent sections={content.sections} />
           </main>
 
           <LinksSidebar
             groups={[
               {
-                links: content.sidebar_links.map((link) => ({
-                  href: GETTING_STARTED_LINKS[link.link],
+                links: content.links.map((link) => ({
+                  href: SCHOLARSHIPS_LINKS[link.link],
                   label: link.label,
                 })),
                 title: content.important_links,
+              },
+              {
+                links: content.contact_links.map((link) => ({
+                  href: SCHOLARSHIPS_LINKS[link.link],
+                  label: link.label,
+                  variant: "secondary" as const,
+                })),
+                title: content.contact_title,
               },
             ]}
           />

--- a/src/app/(app)/[lang]/international/scholarships/scholarships.constants.ts
+++ b/src/app/(app)/[lang]/international/scholarships/scholarships.constants.ts
@@ -1,0 +1,9 @@
+import type { ScholarshipsLinkKey } from "./scholarships.types";
+
+/** Targets of the buttons on the page. */
+export const SCHOLARSHIPS_LINKS: Record<ScholarshipsLinkKey, string> = {
+  mueper: "https://mueper.bme.hu",
+  eszb: "http://ehk.bme.hu/eszb",
+  grants_email: "mailto:palyazat@bmeehk.hu",
+  social_email: "mailto:szoc@bmeehk.hu",
+};

--- a/src/app/(app)/[lang]/international/scholarships/scholarships.types.ts
+++ b/src/app/(app)/[lang]/international/scholarships/scholarships.types.ts
@@ -1,0 +1,29 @@
+import type { ContentBlock } from "@/components/common/ContentBlocks";
+
+export type ScholarshipsLinkKey =
+  | "mueper"
+  | "eszb"
+  | "grants_email"
+  | "social_email";
+
+/** A pill button pointing at one of the links in the constants file. */
+export interface ScholarshipsAction {
+  label: string;
+  link: ScholarshipsLinkKey;
+}
+
+export interface ScholarshipsSection {
+  title: string;
+  blocks: ContentBlock[];
+  actions?: ScholarshipsAction[];
+}
+
+export interface Scholarships {
+  title: string;
+  intro: string;
+  important_links: string;
+  contact_title: string;
+  links: ScholarshipsAction[];
+  contact_links: ScholarshipsAction[];
+  sections: ScholarshipsSection[];
+}

--- a/src/app/(app)/components/navigation-items.ts
+++ b/src/app/(app)/components/navigation-items.ts
@@ -257,6 +257,12 @@ export function getNavigationItems(lang: string): NavigationItem[] {
           targetBlank: false,
         },
         {
+          label: t("Ösztöndíjak", "Scholarships"),
+          subtitle: t("Egyetemi és kari ösztöndíjak, tanulmányi és szociális támogatás", "University and faculty scholarships, academic and social support"),
+          href: link("/international/scholarships"),
+          targetBlank: false,
+        },
+        {
           label: t("Kollégium", "Housing"),
           subtitle: t("Kollégiumi pályázás, jogosultság és a felvétel menete", "Dormitory application, eligibility, and the admission process"),
           href: link("/international/housing"),

--- a/src/components/common/ActionLink.tsx
+++ b/src/components/common/ActionLink.tsx
@@ -1,40 +1,59 @@
-import { ArrowRight, ExternalLink } from "lucide-react";
+import { ArrowRight, ExternalLink, Mail } from "lucide-react";
 import Link from "next/link";
 
+export type ActionLinkVariant = "primary" | "secondary";
+
 interface ActionLinkProps {
-  /** Absolute URL, or a site-relative path already carrying the locale prefix. */
+  /** Absolute URL, mailto:, or a site-relative path already carrying the locale prefix. */
   href: string;
   label: string;
+  variant?: ActionLinkVariant;
   className?: string;
 }
 
-const actionLinkClassName =
-  "group flex items-center gap-2 rounded-2xl border border-ehk-dark-red bg-ehk-dark-red px-4 py-2 text-left font-open-sans text-xs uppercase leading-[1.5] text-white transition-colors hover:border-ehk-light-red hover:bg-ehk-light-red focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ehk-dark-red";
+const baseClassName =
+  "group flex items-center gap-2 rounded-2xl border px-4 py-2 text-left font-open-sans text-xs uppercase leading-[1.5] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ehk-dark-red";
+
+const variantClassName: Record<ActionLinkVariant, string> = {
+  primary:
+    "border-ehk-dark-red bg-ehk-dark-red text-white hover:border-ehk-light-red hover:bg-ehk-light-red",
+  secondary:
+    "border-[#e9e2d6] bg-[#f9f4f0] text-[#3d3d3d] hover:border-ehk-dark-red hover:text-ehk-dark-red",
+};
 
 /**
- * Red pill button. Site-relative hrefs navigate in place and get an arrow,
- * everything else opens in a new tab with the external-link glyph.
+ * Pill button. Site-relative hrefs navigate in place and get an arrow, mailto:
+ * links get an envelope, and everything else opens in a new tab with the
+ * external-link glyph.
  */
 export function ActionLink({
   href,
   label,
+  variant = "primary",
   className = "",
 }: Readonly<ActionLinkProps>) {
   const isInternal = href.startsWith("/");
+  const isMail = href.startsWith("mailto:");
+  const fullClassName = `${baseClassName} ${variantClassName[variant]} ${className}`;
+
+  const icon = isInternal ? (
+    <ArrowRight className="h-4 w-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
+  ) : isMail ? (
+    <Mail className="h-4 w-4 shrink-0" />
+  ) : (
+    <ExternalLink className="h-4 w-4 shrink-0 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+  );
+
   const content = (
     <>
       <span className="min-w-0 flex-1">{label}</span>
-      {isInternal ? (
-        <ArrowRight className="h-4 w-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
-      ) : (
-        <ExternalLink className="h-4 w-4 shrink-0 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
-      )}
+      {icon}
     </>
   );
 
   if (isInternal) {
     return (
-      <Link className={`${actionLinkClassName} ${className}`} href={href}>
+      <Link className={fullClassName} href={href}>
         {content}
       </Link>
     );
@@ -42,10 +61,10 @@ export function ActionLink({
 
   return (
     <a
-      className={`${actionLinkClassName} ${className}`}
+      className={fullClassName}
       href={href}
-      rel="noopener noreferrer"
-      target="_blank"
+      rel={isMail ? undefined : "noopener noreferrer"}
+      target={isMail ? undefined : "_blank"}
     >
       {content}
     </a>

--- a/src/components/common/LinksSidebar.tsx
+++ b/src/components/common/LinksSidebar.tsx
@@ -1,11 +1,15 @@
-import { ActionLink } from "@/components/common/ActionLink";
+import {
+  ActionLink,
+  type ActionLinkVariant,
+} from "@/components/common/ActionLink";
 
 export interface SidebarActionLink {
   label: string;
   href: string;
+  variant?: ActionLinkVariant;
 }
 
-interface LinksSidebarProps {
+export interface SidebarGroup {
   /** Small uppercase heading, e.g. "Important links". */
   title?: string;
   /** Introductory sentence shown above the buttons. */
@@ -18,34 +22,40 @@ interface LinksSidebarProps {
  * panel from `xl` up and follows the reader while they scroll.
  */
 export function LinksSidebar({
-  title,
-  description,
-  links,
-}: Readonly<LinksSidebarProps>) {
+  groups,
+}: Readonly<{ groups: SidebarGroup[] }>) {
   return (
-    <aside className="mt-4 flex h-fit flex-col gap-4 rounded-2xl border border-[#e9e2d6] bg-[#fffefc] p-4 xl:sticky xl:top-8 xl:mt-8 xl:rounded-l-none xl:border-l-0">
-      {title && (
-        <h2 className="py-1 font-open-sans text-[13px] font-semibold uppercase leading-none tracking-[0.1em] text-[#6e6660]">
-          {title}
-        </h2>
-      )}
+    <aside className="mt-4 flex h-fit flex-col gap-6 rounded-2xl border border-[#e9e2d6] bg-[#fffefc] p-4 xl:sticky xl:top-8 xl:mt-8 xl:rounded-l-none xl:border-l-0">
+      {groups.map((group) => (
+        <div
+          className="flex flex-col gap-4"
+          key={group.title ?? group.links[0]?.href}
+        >
+          {group.title && (
+            <h2 className="py-1 font-open-sans text-[13px] font-semibold uppercase leading-none tracking-[0.1em] text-[#6e6660]">
+              {group.title}
+            </h2>
+          )}
 
-      {description && (
-        <p className="font-open-sans text-sm leading-[1.6] text-black">
-          {description}
-        </p>
-      )}
+          {group.description && (
+            <p className="font-open-sans text-sm leading-[1.6] text-black">
+              {group.description}
+            </p>
+          )}
 
-      <div className="flex flex-col items-start gap-2">
-        {links.map((link) => (
-          <ActionLink
-            className="max-w-full"
-            href={link.href}
-            key={link.href}
-            label={link.label}
-          />
-        ))}
-      </div>
+          <div className="flex flex-col items-start gap-2">
+            {group.links.map((link) => (
+              <ActionLink
+                className="max-w-full"
+                href={link.href}
+                key={link.href}
+                label={link.label}
+                variant={link.variant}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
     </aside>
   );
 }

--- a/src/dictionaries/en/international_scholarships.json
+++ b/src/dictionaries/en/international_scholarships.json
@@ -1,0 +1,90 @@
+{
+  "international": {
+    "scholarships": {
+      "title": "SCHOLARSHIPS",
+      "intro": "Applications for most scholarships are submitted online via MŰEPER (Unified Application and Evaluation System). Requirements may vary by faculty — see below for details on specific scholarships.",
+      "important_links": "Important links",
+      "contact_title": "Contact",
+      "links": [
+        { "label": "MŰEPER", "link": "mueper" },
+        { "label": "University Social Committee (ESZB)", "link": "eszb" }
+      ],
+      "contact_links": [
+        { "label": "palyazat@bmeehk.hu", "link": "grants_email" }
+      ],
+      "sections": [
+        {
+          "title": "University-level scholarships",
+          "blocks": [
+            {
+              "type": "list",
+              "items": [
+                {
+                  "emphasis": "University BME Scholarship",
+                  "text": "(Egyetemi BME Ösztöndíj) – Rewards students who achieved the most professional and scientific merit in the specified semester. Open to active full-time students in undergraduate, master's, or undivided programs with outstanding academic, professional, and scientific activities."
+                },
+                {
+                  "emphasis": "Good Student, Good Athlete",
+                  "text": "(Jó Tanuló, Jó Sportoló) – For applicants with a scholarship index of at least 3.00 in the last two semesters, or who achieved results in recognized sports competitions (Olympics, World/European Championships, UNIVERSIADE, MEFOB, national/regional competitions, and more)."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Faculty-level scholarships",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "Application requirements may differ by faculty, consult your Faculty Student Council for details."
+            },
+            {
+              "type": "list",
+              "items": [
+                {
+                  "emphasis": "Public Life Scholarship",
+                  "text": "(Közéleti ösztöndíj) – For students carrying out community activities that contribute to the Faculty Student Union's work. (ÉMK, GPK, VBK, VIK, ÉPK, GTK)"
+                },
+                {
+                  "emphasis": "Community Scholarship",
+                  "text": "(Közösségi ösztöndíj) – For outstanding community work within Student Organizations, external committees, or as event organizers. (GPK, VBK, ÉPK, GTK, KJK, TTK)"
+                },
+                {
+                  "emphasis": "Students for Education Scholarship",
+                  "text": "(Hallgatók az oktatásért ösztöndíj) – For students carrying out tutoring activities at their faculty. (VBK, ÉPK, VIK, GTK)"
+                },
+                {
+                  "emphasis": "Faculty BME Scholarship",
+                  "text": "(Kari BME ösztöndíj) – For outstanding professional, scientific, academic, or language achievements at the faculty level. (VBK, GPK, ÉPK, VIK, KJK, GTK)"
+                },
+                {
+                  "emphasis": "Sports Scholarship",
+                  "text": "(Sportösztöndíj) – For students with outstanding sports results alongside their studies. (GPK, VIK)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Academic scholarship",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "A merit-based grant awarded to students with outstanding academic results in the previous active semester, based on the scholarship index within your Homogeneous Student Group (HHCS). The Faculty Student Union administers this scholarship and publishes results within 5 working days of the decision."
+            }
+          ]
+        },
+        {
+          "title": "Regular social scholarship",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "For full-time students in state-funded or state scholarship-supported programs, based on social circumstances. Only one application per student is allowed per scholarship. Submitted via MŰEPER during the application period."
+            }
+          ],
+          "actions": [{ "label": "Contact", "link": "social_email" }]
+        }
+      ]
+    }
+  }
+}

--- a/src/dictionaries/hu/international_scholarships.json
+++ b/src/dictionaries/hu/international_scholarships.json
@@ -1,0 +1,90 @@
+{
+  "international": {
+    "scholarships": {
+      "title": "ÖSZTÖNDÍJAK",
+      "intro": "A legtöbb ösztöndíjra online, a MŰEPER (Műegyetemi Egységes Pályázati és Elbírálási Rendszer) felületén lehet pályázni. A feltételek karonként eltérhetnek – a részleteket az egyes ösztöndíjaknál találod.",
+      "important_links": "Fontos linkek",
+      "contact_title": "Kapcsolat",
+      "links": [
+        { "label": "MŰEPER", "link": "mueper" },
+        { "label": "Egyetemi Szociális Bizottság (ESZB)", "link": "eszb" }
+      ],
+      "contact_links": [
+        { "label": "palyazat@bmeehk.hu", "link": "grants_email" }
+      ],
+      "sections": [
+        {
+          "title": "Egyetemi szintű ösztöndíjak",
+          "blocks": [
+            {
+              "type": "list",
+              "items": [
+                {
+                  "emphasis": "Egyetemi BME Ösztöndíj",
+                  "text": "– Az adott félévben a legkiemelkedőbb szakmai és tudományos teljesítményt nyújtó hallgatókat díjazza. Aktív, nappali tagozatos alap-, mester- és osztatlan képzésben részt vevő hallgatók pályázhatnak kiemelkedő tanulmányi, szakmai és tudományos tevékenységgel."
+                },
+                {
+                  "emphasis": "Jó Tanuló, Jó Sportoló",
+                  "text": "– Azok pályázhatnak, akiknek az elmúlt két félévben legalább 3,00 volt az ösztöndíjindexük, vagy eredményt értek el elismert sportversenyeken (olimpia, világ- és Európa-bajnokság, UNIVERSIADE, MEFOB, országos és területi versenyek, és további megmérettetések)."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Kari szintű ösztöndíjak",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "A pályázati feltételek karonként eltérhetnek, a részletekért fordulj a kari hallgatói képviseletedhez."
+            },
+            {
+              "type": "list",
+              "items": [
+                {
+                  "emphasis": "Közéleti ösztöndíj",
+                  "text": "– Azoknak a hallgatóknak, akik a kari hallgatói képviselet munkáját segítő közéleti tevékenységet végeznek. (ÉMK, GPK, VBK, VIK, ÉPK, GTK)"
+                },
+                {
+                  "emphasis": "Közösségi ösztöndíj",
+                  "text": "– Az öntevékeny körökben, külsős bizottságokban vagy rendezvényszervezőként végzett kiemelkedő közösségi munkáért. (GPK, VBK, ÉPK, GTK, KJK, TTK)"
+                },
+                {
+                  "emphasis": "Hallgatók az oktatásért ösztöndíj",
+                  "text": "– Azoknak a hallgatóknak, akik a karukon korrepetálási tevékenységet végeznek. (VBK, ÉPK, VIK, GTK)"
+                },
+                {
+                  "emphasis": "Kari BME ösztöndíj",
+                  "text": "– Kiemelkedő kari szintű szakmai, tudományos, tanulmányi vagy nyelvi teljesítményért. (VBK, GPK, ÉPK, VIK, KJK, GTK)"
+                },
+                {
+                  "emphasis": "Sportösztöndíj",
+                  "text": "– Azoknak a hallgatóknak, akik a tanulmányaik mellett kiemelkedő sporteredményeket érnek el. (GPK, VIK)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Tanulmányi ösztöndíj",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "Teljesítményalapú juttatás azoknak a hallgatóknak, akik az előző aktív félévben kiemelkedő tanulmányi eredményt értek el, a homogén hallgatói csoporton (HHCS) belüli ösztöndíjindex alapján. Az ösztöndíjat a kari hallgatói képviselet kezeli, az eredményeket a döntéstől számított 5 munkanapon belül teszi közzé."
+            }
+          ]
+        },
+        {
+          "title": "Rendszeres szociális ösztöndíj",
+          "blocks": [
+            {
+              "type": "paragraph",
+              "text": "Államilag támogatott vagy állami ösztöndíjas, nappali tagozatos hallgatóknak, a szociális helyzet alapján. Ösztöndíjanként csak egy pályázat adható be hallgatónként. A pályázat a MŰEPER-en keresztül nyújtható be a pályázati időszakban."
+            }
+          ],
+          "actions": [{ "label": "Kapcsolat", "link": "social_email" }]
+        }
+      ]
+    }
+  }
+}

--- a/src/get-dictionary.ts
+++ b/src/get-dictionary.ts
@@ -19,6 +19,7 @@ export type Namespace =
   | 'international_getting_started'
   | 'international_education'
   | 'international_housing'
+  | 'international_scholarships'
   | 'international_mobility'
   | 'erasmus'
   | 'eelisa'
@@ -42,6 +43,7 @@ export type DictionaryMap = {
   international_getting_started: typeof import('./dictionaries/hu/international_getting_started.json');
   international_education: typeof import('./dictionaries/hu/international_education.json');
   international_housing: typeof import('./dictionaries/hu/international_housing.json');
+  international_scholarships: typeof import('./dictionaries/hu/international_scholarships.json');
   international_mobility: typeof import('./dictionaries/hu/international_mobility.json');
   erasmus: typeof import('./dictionaries/hu/erasmus.json');
   eelisa: typeof import('./dictionaries/hu/eelisa.json');
@@ -73,6 +75,7 @@ const loaders: Record<Locale, { [K in Namespace]: () => Promise<DictionaryMap[K]
     international_getting_started: () => load<'international_getting_started'>(import('./dictionaries/hu/international_getting_started.json')),
     international_education: () => load<'international_education'>(import('./dictionaries/hu/international_education.json')),
     international_housing: () => load<'international_housing'>(import('./dictionaries/hu/international_housing.json')),
+    international_scholarships: () => load<'international_scholarships'>(import('./dictionaries/hu/international_scholarships.json')),
     international_mobility: () => load<'international_mobility'>(import('./dictionaries/hu/international_mobility.json')),
     erasmus: () => load<'erasmus'>(import('./dictionaries/hu/erasmus.json')),
     eelisa: () => load<'eelisa'>(import('./dictionaries/hu/eelisa.json')),
@@ -96,6 +99,7 @@ const loaders: Record<Locale, { [K in Namespace]: () => Promise<DictionaryMap[K]
     international_getting_started: () => load<'international_getting_started'>(import('./dictionaries/en/international_getting_started.json')),
     international_education: () => load<'international_education'>(import('./dictionaries/en/international_education.json')),
     international_housing: () => load<'international_housing'>(import('./dictionaries/en/international_housing.json')),
+    international_scholarships: () => load<'international_scholarships'>(import('./dictionaries/en/international_scholarships.json')),
     international_mobility: () => load<'international_mobility'>(import('./dictionaries/en/international_mobility.json')),
     erasmus: () => load<'erasmus'>(import('./dictionaries/en/erasmus.json')),
     eelisa: () => load<'eelisa'>(import('./dictionaries/en/eelisa.json')),


### PR DESCRIPTION
> **Stacked PR** — a #186 (news és application info törlése) tetejére épül, ami a #185 → #184 → #183 → #182 láncra.

## Mit csinál

A Figma design alapján elkészült az angol nyelvű **Scholarships** oldal az international szekcióban. Ez az egyetlen eddigi, amely nem meglévő oldalt vált ki — a most törölt Application Information ösztöndíj-tartalmát pótolja.

- Új útvonal: `/en/international/scholarships`, új menüpont az INTERNATIONAL menüben.
- Négy szekciókártya: *University-level scholarships*, *Faculty-level scholarships*, *Academic scholarship*, *Regular social scholarship*.
- A bevezető szöveg a piros fejlécben, a design szerint.
- Sidebar **két blokkal**: *Important links* (MŰEPER, ESZB) és *Contact* (palyazat@bmeehk.hu, világos gombstílussal).

## Közös komponensek

- `ActionLink`: új `secondary` variáns (világos háttér, sötét szöveg) a sidebar kapcsolat-gombjához, és `mailto:` célnál boríték ikon, új lap nyitása nélkül.
- `LinksSidebar`: eddig egy címet és egy linklistát kapott, mostantól `groups` tömböt, így egy sidebar több címzett blokkot is tartalmazhat. A getting started, education és housing oldal hívása ehhez igazítva (egyelemű tömb).

## Linkek

- MŰEPER → `mueper.bme.hu`, ESZB → `ehk.bme.hu/eszb` (a repóban is használt http-s változat).
- A sidebar kapcsolat gombja `palyazat@bmeehk.hu` (a designban ez szerepel), a *Regular social scholarship* kártya CONTACT gombja `szoc@bmeehk.hu` — ez utóbbi következtetés a szociális ösztöndíj témája alapján, szólj, ha másik cím kell.

## Tesztelés

- `yarn lint` és `tsc --noEmit` tiszta.
- Kézzel ellenőrizve 1440px-en: a két sidebar-blokk, a félkövér ösztöndíjnevek és a gombok a design szerint jelennek meg, mind a négy link a várt célra mutat.
- A getting started, education és housing oldal a `LinksSidebar` API-váltás után változatlanul renderel.