### PR TITLE
fix: mobil reszponzivitási hibák javítása

### DIFF
--- a/src/app/(app)/[lang]/hirek/[slug]/components/RelatedNewsClient.tsx
+++ b/src/app/(app)/[lang]/hirek/[slug]/components/RelatedNewsClient.tsx
@@ -33,7 +33,7 @@ export function RelatedNewsClient({ relatedArticles }: { relatedArticles: News[]
                     {tags.map((rawTag, index) => (
                       <span
                         key={`${rawTag}-${index}`}
-                        className="inline-flex items-center justify-center rounded-full border border-[#3d3d3d] bg-white px-2 py-1 text-[11px] md:text-[10px] leading-none text-[#3d3d3d] uppercase"
+                        className="inline-flex items-center justify-center rounded-full border border-[#3d3d3d] bg-white px-2 py-1 text-[11px] leading-none text-[#3d3d3d] uppercase"
                       >
                         {translateTag(rawTag, lang)}
                       </span>

--- a/src/app/(app)/[lang]/hirek/[slug]/components/RelatedNewsClient.tsx
+++ b/src/app/(app)/[lang]/hirek/[slug]/components/RelatedNewsClient.tsx
@@ -33,7 +33,7 @@ export function RelatedNewsClient({ relatedArticles }: { relatedArticles: News[]
                     {tags.map((rawTag, index) => (
                       <span
                         key={`${rawTag}-${index}`}
-                        className="inline-flex items-center justify-center rounded-full border border-[#3d3d3d] bg-white px-1.5 py-0.5 text-[8px] leading-none text-[#3d3d3d] uppercase"
+                        className="inline-flex items-center justify-center rounded-full border border-[#3d3d3d] bg-white px-2 py-1 text-[11px] md:text-[10px] leading-none text-[#3d3d3d] uppercase"
                       >
                         {translateTag(rawTag, lang)}
                       </span>

--- a/src/app/(app)/[lang]/kepviselok/components/RepresentativeCard.tsx
+++ b/src/app/(app)/[lang]/kepviselok/components/RepresentativeCard.tsx
@@ -81,12 +81,12 @@ export function RepresentativeCard({ representative, onClickAction }: Readonly<R
                     )}
 
                     {representative.emails && representative.emails.length > 0 && (
-                        <div className="flex flex-col items-center gap-1">
+                        <div className="flex flex-col items-center">
                             {representative.emails.map((emailObj, index) => (
                                 <a
                                     key={`${emailObj.email}-${index}`}
                                     href={`mailto:${emailObj.email}`}
-                                    className="inline-flex items-center justify-center gap-1 font-open-sans text-[13px] font-semibold leading-none text-black transition-colors hover:text-[#862633] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#862633] focus-visible:ring-offset-2"
+                                    className="inline-flex min-h-11 items-center justify-center gap-1 font-open-sans text-[13px] font-semibold leading-none text-black transition-colors hover:text-[#862633] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#862633] focus-visible:ring-offset-2"
                                     onClick={(event) => event.stopPropagation()}
                                 >
                                     <Mail className="h-3.75 w-3.75 shrink-0" />

--- a/src/app/(app)/[lang]/page.tsx
+++ b/src/app/(app)/[lang]/page.tsx
@@ -57,7 +57,7 @@ export default async function Home({
             <div className="max-w-350 mx-auto">
               <div id="main-content-section" className="h-0" aria-hidden />
 
-              <div className="grid grid-cols-1 lg:grid-cols-[15rem_1fr] gap-8 items-start -mt-16 lg:-mt-24 relative z-10">
+              <div className="grid grid-cols-1 lg:grid-cols-[15rem_1fr] gap-8 items-start mt-0 lg:-mt-24 relative z-10">
 
                 <aside className="flex flex-col gap-4 order-2 lg:order-1 w-full lg:max-w-60">
                   <OfficeHours />

--- a/src/app/(app)/components/Footer.tsx
+++ b/src/app/(app)/components/Footer.tsx
@@ -84,7 +84,7 @@ export default function Footer({ universityPages = [] }: FooterProps) {
                                         <span className="font-open-sans font-bold text-base text-[#1a1a1a] tracking-tight">{card.name}</span>
                                         <ExternalLink className="w-4 h-4 text-[#6e6660] shrink-0" />
                                     </div>
-                                    <span className="hidden sm:block font-open-sans text-xs text-[#6e6660] mt-1">
+                                    <span className="sr-only sm:not-sr-only sm:block font-open-sans text-xs text-[#6e6660] sm:mt-1">
                                         {t("Kari Hallgatói Képviselet", "Faculty Student Representation")}
                                     </span>
                                 </Link>

--- a/src/app/(app)/components/Footer.tsx
+++ b/src/app/(app)/components/Footer.tsx
@@ -24,8 +24,8 @@ export default function Footer({ universityPages = [] }: FooterProps) {
     ];
 
     return (
-        <footer className="bg-[#fbf9f6] text-[#1a1a1a] border-t border-[#e9e2d6] py-8 font-open-sans">
-            <div className="container mx-auto">
+        <footer className="bg-[#fbf9f6] text-[#1a1a1a] border-t border-[#e9e2d6] pt-8 pb-28 md:pb-8 font-open-sans">
+            <div className="container mx-auto px-4 md:px-6">
                 <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-stretch">
                     
                     {/* KAPCSOLAT Section */}
@@ -41,7 +41,7 @@ export default function Footer({ universityPages = [] }: FooterProps) {
                             <p>{t('footer.contact.address_value') || "1111 Budapest, Műegyetem rkp. 7-9. R. ép. 2.07."}</p>
                             <p>+36-1-463-3836</p>
                         </div>
-                        <ul className="space-y-1.5 mt-2">
+                        <ul className="mt-2">
                             {[
                                 "info@bmeehk.hu",
                                 "palyazat@bmeehk.hu",
@@ -53,7 +53,7 @@ export default function Footer({ universityPages = [] }: FooterProps) {
                                     <span className="text-[#B2293B] font-bold text-lg leading-none select-none">•</span>
                                     <Link
                                         href={`mailto:${email}`}
-                                        className="text-[#1a1a1a] hover:text-[#B2293B] hover:underline transition-colors duration-150"
+                                        className="flex min-h-11 items-center text-[#1a1a1a] hover:text-[#B2293B] hover:underline transition-colors duration-150"
                                     >
                                         {email}
                                     </Link>
@@ -71,7 +71,7 @@ export default function Footer({ universityPages = [] }: FooterProps) {
                         <p className="font-open-sans font-bold text-xs text-[#9a9a9a] uppercase tracking-wider">
                             {t('footer.faculty_representation.title')}
                         </p>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 w-full mt-2">
+                        <div className="grid grid-cols-2 gap-2 w-full mt-2">
                             {representativeCards.map((card) => (
                                 <Link
                                     key={card.name}
@@ -84,7 +84,7 @@ export default function Footer({ universityPages = [] }: FooterProps) {
                                         <span className="font-open-sans font-bold text-base text-[#1a1a1a] tracking-tight">{card.name}</span>
                                         <ExternalLink className="w-4 h-4 text-[#6e6660] shrink-0" />
                                     </div>
-                                    <span className="font-open-sans text-xs text-[#6e6660] mt-1">
+                                    <span className="hidden sm:block font-open-sans text-xs text-[#6e6660] mt-1">
                                         {t("Kari Hallgatói Képviselet", "Faculty Student Representation")}
                                     </span>
                                 </Link>
@@ -101,7 +101,7 @@ export default function Footer({ universityPages = [] }: FooterProps) {
                         <p className="font-open-sans font-bold text-xs text-[#9a9a9a] uppercase tracking-wider">
                             {t('footer.university_pages.title')}
                         </p>
-                        <div className="flex flex-col gap-3 font-open-sans text-base text-[#1a1a1a] mt-2">
+                        <div className="flex flex-col font-open-sans text-base text-[#1a1a1a] mt-2">
                             {universityPages.map((page) => {
                                 const normalizedLang = lang?.toUpperCase();
                                 const title = (normalizedLang === "EN" ? page.title_en : page.title_hu)
@@ -114,7 +114,7 @@ export default function Footer({ universityPages = [] }: FooterProps) {
                                         href={page.url}
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        className="hover:underline hover:text-[#B2293B] transition-colors duration-150"
+                                        className="flex min-h-11 items-center hover:underline hover:text-[#B2293B] transition-colors duration-150"
                                     >
                                         {title}
                                     </Link>
@@ -128,7 +128,7 @@ export default function Footer({ universityPages = [] }: FooterProps) {
                 {/* Bottom section with Logo and Credits */}
                 <div className="flex flex-col justify-center items-center pt-8 border-t border-[#e9e2d6] mt-16 gap-4">
                     <p className="text-xs text-[#6e6660]">
-                        Made with 🤍 by <a href="https://kir-dev.hu" className="underline hover:text-[#1a1a1a] transition-colors" target="_blank" rel="noopener noreferrer">Kir-Dev</a>
+                        Made with 🤍 by <a href="https://kir-dev.hu" className="inline-flex min-h-11 items-center px-2 underline hover:text-[#1a1a1a] transition-colors" target="_blank" rel="noopener noreferrer">Kir-Dev</a>
                     </p>
                 </div>
             </div>

--- a/src/app/(app)/components/ImageViewer.tsx
+++ b/src/app/(app)/components/ImageViewer.tsx
@@ -46,7 +46,7 @@ export default function ImageViewer({ images = [] }: ImageViewerProps) {
         <div className="max-w-screen mx-auto">
             <div className="relative bg-transparent overflow-hidden w-full">
                 {/* Main Image Container */}
-                <div className="relative w-full aspect-10/3">
+                <div className="relative w-full aspect-16/9 sm:aspect-21/9 lg:aspect-10/3">
                     {/* Keep the aspect ratio of the upoaded image approximately 30/9=10/3 to ensure best appearence*/}
                     {/* One such good ratio is, if the image is 1200px wide and 360px high or 1400px wide and 420px high*/}
                     <Image
@@ -61,7 +61,7 @@ export default function ImageViewer({ images = [] }: ImageViewerProps) {
                     <Button
                         variant="ghost"
                         size="icon"
-                        className="absolute left-4 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white border-0 h-12 w-12 rounded-full"
+                        className="absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white border-0 h-11 w-11 sm:h-12 sm:w-12 rounded-full"
                         onClick={goToPrevious}
                         aria-label={t('Előző kép', 'Previous image')}
                     >
@@ -71,7 +71,7 @@ export default function ImageViewer({ images = [] }: ImageViewerProps) {
                     <Button
                         variant="ghost"
                         size="icon"
-                        className="absolute right-4 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white border-0 h-12 w-12 rounded-full"
+                        className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white border-0 h-11 w-11 sm:h-12 sm:w-12 rounded-full"
                         onClick={goToNext}
                         aria-label={t('Következő kép', 'Next image')}
                     >
@@ -85,13 +85,13 @@ export default function ImageViewer({ images = [] }: ImageViewerProps) {
                 </div>
 
                 {/* Dot Indicators */}
-                <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex space-x-2">
+                <div className="absolute bottom-1 left-1/2 -translate-x-1/2 flex">
                     {images.map((_, index) => (
                         <button
                             key={index}
                             onClick={() => goToSlide(index)}
                             className={cn(
-                                "w-3 h-3 rounded-full transition-all duration-200 hover:scale-110",
+                                "w-3 h-3 box-content p-4 bg-clip-content rounded-full transition-all duration-200 hover:scale-110",
                                 index === currentIndex ? "bg-white shadow-lg" : "bg-white/50 hover:bg-white/70",
                             )}
                             aria-label={t(`Ugrás a(z) ${index + 1}. képre`, `Go to image ${index + 1}`)}

--- a/src/app/(app)/components/ImageViewer.tsx
+++ b/src/app/(app)/components/ImageViewer.tsx
@@ -84,14 +84,17 @@ export default function ImageViewer({ images = [] }: ImageViewerProps) {
                     </div>
                 </div>
 
-                {/* Dot Indicators */}
-                <div className="absolute bottom-1 left-1/2 -translate-x-1/2 flex">
+                {/* Dot Indicators — each dot carries a 44px tap target, so a large
+                    hero set can outgrow a narrow viewport. Span the full width and
+                    scroll instead; "safe center" keeps the first dot reachable
+                    rather than centring the overflow out of view. */}
+                <div className="absolute inset-x-0 bottom-1 flex overflow-x-auto [justify-content:safe_center] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                     {images.map((_, index) => (
                         <button
                             key={index}
                             onClick={() => goToSlide(index)}
                             className={cn(
-                                "w-3 h-3 box-content p-4 bg-clip-content rounded-full transition-all duration-200 hover:scale-110",
+                                "w-3 h-3 shrink-0 box-content p-4 bg-clip-content rounded-full transition-all duration-200 hover:scale-110",
                                 index === currentIndex ? "bg-white shadow-lg" : "bg-white/50 hover:bg-white/70",
                             )}
                             aria-label={t(`Ugrás a(z) ${index + 1}. képre`, `Go to image ${index + 1}`)}

--- a/src/app/(app)/components/MuhelyWidget.tsx
+++ b/src/app/(app)/components/MuhelyWidget.tsx
@@ -30,7 +30,7 @@ export default function MuhelyWidget({ className }: Readonly<Props>) {
         href="https://muhely.bme.hu/"
         target="_blank"
         rel="noopener noreferrer"
-        className="bg-[#fbe4d3] hover:bg-[#f5cfb5] text-[#6b0f1a] font-open-sans font-semibold text-[13px] px-4 py-1.5 rounded-full w-fit transition-all duration-300 mt-2 block shadow-sm hover:shadow-md"
+        className="bg-[#fbe4d3] hover:bg-[#f5cfb5] text-[#6b0f1a] font-open-sans font-semibold text-[13px] px-4 py-2.5 rounded-full w-fit transition-all duration-300 mt-2 inline-flex min-h-11 items-center shadow-sm hover:shadow-md"
       >
         {t("widgets.muhely_btn", "Olvasom")}
       </Link>

--- a/src/app/(app)/components/NewsFilter.tsx
+++ b/src/app/(app)/components/NewsFilter.tsx
@@ -84,7 +84,7 @@ export default function NewsFilter({
                 key={tag}
                 type="button"
                 onClick={() => onTagClick(tag)}
-                className={`inline-flex items-center justify-center px-2.5 py-1 rounded-full text-sm font-open-sans font-normal transition-colors duration-200 select-none cursor-pointer border ${
+                className={`inline-flex min-h-11 items-center justify-center px-3 py-2 rounded-full text-sm font-open-sans font-normal transition-colors duration-200 select-none cursor-pointer border ${
                   isActive
                     ? "bg-[#ffe6e6] text-[#862633] border-[#862633] hover:bg-[#ffe6e6]/80"
                     : "bg-transparent text-[#3d3d3d] border-[#3d3d3d] hover:bg-[#3d3d3d]/5"

--- a/src/app/(app)/components/events/EventsListClient.tsx
+++ b/src/app/(app)/components/events/EventsListClient.tsx
@@ -24,6 +24,7 @@ export default function EventsListClient({ lang, events, dictionary }: Readonly<
     handleShare,
     handleScroll,
     totalWeeksCount,
+    visibleWeeks,
   } = useEventsLogic({ lang, events, dictionary })
 
   return (
@@ -39,6 +40,7 @@ export default function EventsListClient({ lang, events, dictionary }: Readonly<
         t={t}
         lang={lang}
         totalWeeksCount={totalWeeksCount}
+        visibleWeeks={visibleWeeks}
       />
 
       {/* Vertical Scroll View of Day-Grouped Events */}

--- a/src/app/(app)/components/events/EventsListClient.tsx
+++ b/src/app/(app)/components/events/EventsListClient.tsx
@@ -45,7 +45,7 @@ export default function EventsListClient({ lang, events, dictionary }: Readonly<
       <div 
         ref={scrollContainerRef}
         onScroll={handleScroll}
-        className="flex flex-col w-full overflow-y-auto max-h-162.5 pr-2 relative"
+        className="flex flex-col w-full md:overflow-y-auto md:max-h-162.5 md:pr-2 relative"
         style={{ scrollbarWidth: "thin", scrollbarColor: "rgba(134, 38, 51, 0.3) transparent", overflowAnchor: "none" }}
       >
         {renderedWeekData.map((week) => {

--- a/src/app/(app)/components/events/EventsTimeline.tsx
+++ b/src/app/(app)/components/events/EventsTimeline.tsx
@@ -17,7 +17,7 @@ export function EventsTimeline({
 }: Readonly<EventsTimelineProps>) {
   return (
     <div 
-      className="bg-[#862633] text-white flex gap-2 h-14 items-center px-4 py-2 relative rounded-2xl w-full shadow-md mb-8 select-none"
+      className="bg-[#862633] text-white flex gap-1 sm:gap-2 min-h-14 items-center px-2 sm:px-4 py-2 relative rounded-2xl w-full shadow-md mb-8 select-none"
       data-name="Timeline"
     >
       {/* Left Arrow */}
@@ -25,7 +25,7 @@ export function EventsTimeline({
         onClick={() => onShiftTimeline("left")}
         disabled={timelineStartIdx === startWeekIndex}
         className={cn(
-          "h-8 w-8 flex items-center justify-center rounded-full hover:bg-white/10 transition-colors shrink-0",
+          "h-11 w-11 flex items-center justify-center rounded-full hover:bg-white/10 transition-colors shrink-0",
           timelineStartIdx === startWeekIndex && "opacity-30 cursor-not-allowed"
         )}
         aria-label="Previous weeks"
@@ -34,11 +34,11 @@ export function EventsTimeline({
       </button>
 
       {/* Weeks Slider Container */}
-      <div className="flex flex-1 gap-2 overflow-hidden justify-center items-center h-full">
-        {weeks.slice(timelineStartIdx - startWeekIndex, timelineStartIdx - startWeekIndex + 3).map((week) => {
+      <div className="flex flex-1 gap-1 sm:gap-2 min-w-0 justify-center items-stretch">
+        {weeks.slice(timelineStartIdx - startWeekIndex, timelineStartIdx - startWeekIndex + 3).map((week, position) => {
           const isActive = activeWeekIndex === week.index
           const weekLabel = formatWeekRange(week.monday, week.sunday, lang)
-          
+
           // Localized custom label for current/next week
           let prefix = ""
           if (week.index === 0) prefix = t.thisWeek
@@ -49,18 +49,20 @@ export function EventsTimeline({
               key={week.index}
               onClick={() => onWeekClick(week.index)}
               className={cn(
-                "flex-1 flex flex-col justify-center items-center h-10 px-2 rounded-lg font-open-sans border border-solid transition-all duration-200 cursor-pointer min-w-0 max-w-[280px]",
+                "flex-1 flex-col justify-center items-center min-h-11 py-1 px-2 rounded-lg font-open-sans border border-solid transition-all duration-200 cursor-pointer min-w-0 max-w-[280px]",
+                // Only two weeks fit legibly on narrow screens; a third would wrap and clip.
+                position === 2 ? "hidden sm:flex" : "flex",
                 isActive
                   ? "bg-white/10 border-[#d3afaf] text-white font-bold"
                   : "bg-[#fffefc] border-[#d3afaf] text-[#6e6660] hover:bg-white/95 font-semibold"
               )}
             >
               {prefix && (
-                <span className="text-[10px] tracking-wide uppercase leading-none opacity-85 mb-0.5">
+                <span className="text-[11px] tracking-wide uppercase leading-tight opacity-85 mb-0.5">
                   {prefix}
                 </span>
               )}
-              <span className="text-xs leading-none">
+              <span className="text-xs leading-tight text-center">
                 {weekLabel}
               </span>
             </button>
@@ -73,7 +75,7 @@ export function EventsTimeline({
         onClick={() => onShiftTimeline("right")}
         disabled={timelineStartIdx >= startWeekIndex + totalWeeksCount - 3}
         className={cn(
-          "h-8 w-8 flex items-center justify-center rounded-full hover:bg-white/10 transition-colors shrink-0",
+          "h-11 w-11 flex items-center justify-center rounded-full hover:bg-white/10 transition-colors shrink-0",
           timelineStartIdx >= startWeekIndex + totalWeeksCount - 3 && "opacity-30 cursor-not-allowed"
         )}
         aria-label="Next weeks"

--- a/src/app/(app)/components/events/EventsTimeline.tsx
+++ b/src/app/(app)/components/events/EventsTimeline.tsx
@@ -14,6 +14,7 @@ export function EventsTimeline({
   t,
   lang,
   totalWeeksCount,
+  visibleWeeks,
 }: Readonly<EventsTimelineProps>) {
   return (
     <div 
@@ -35,7 +36,7 @@ export function EventsTimeline({
 
       {/* Weeks Slider Container */}
       <div className="flex flex-1 gap-1 sm:gap-2 min-w-0 justify-center items-stretch">
-        {weeks.slice(timelineStartIdx - startWeekIndex, timelineStartIdx - startWeekIndex + 3).map((week, position) => {
+        {weeks.slice(timelineStartIdx - startWeekIndex, timelineStartIdx - startWeekIndex + visibleWeeks).map((week) => {
           const isActive = activeWeekIndex === week.index
           const weekLabel = formatWeekRange(week.monday, week.sunday, lang)
 
@@ -49,9 +50,7 @@ export function EventsTimeline({
               key={week.index}
               onClick={() => onWeekClick(week.index)}
               className={cn(
-                "flex-1 flex-col justify-center items-center min-h-11 py-1 px-2 rounded-lg font-open-sans border border-solid transition-all duration-200 cursor-pointer min-w-0 max-w-[280px]",
-                // Only two weeks fit legibly on narrow screens; a third would wrap and clip.
-                position === 2 ? "hidden sm:flex" : "flex",
+                "flex flex-1 flex-col justify-center items-center min-h-11 py-1 px-2 rounded-lg font-open-sans border border-solid transition-all duration-200 cursor-pointer min-w-0 max-w-[280px]",
                 isActive
                   ? "bg-white/10 border-[#d3afaf] text-white font-bold"
                   : "bg-[#fffefc] border-[#d3afaf] text-[#6e6660] hover:bg-white/95 font-semibold"
@@ -73,10 +72,10 @@ export function EventsTimeline({
       {/* Right Arrow */}
       <button
         onClick={() => onShiftTimeline("right")}
-        disabled={timelineStartIdx >= startWeekIndex + totalWeeksCount - 3}
+        disabled={timelineStartIdx >= startWeekIndex + totalWeeksCount - visibleWeeks}
         className={cn(
           "h-11 w-11 flex items-center justify-center rounded-full hover:bg-white/10 transition-colors shrink-0",
-          timelineStartIdx >= startWeekIndex + totalWeeksCount - 3 && "opacity-30 cursor-not-allowed"
+          timelineStartIdx >= startWeekIndex + totalWeeksCount - visibleWeeks && "opacity-30 cursor-not-allowed"
         )}
         aria-label="Next weeks"
       >

--- a/src/app/(app)/components/events/events.constants.ts
+++ b/src/app/(app)/components/events/events.constants.ts
@@ -6,7 +6,15 @@ export const DAYS_EN = ["SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", 
 
 export const TOTAL_WEEKS_COUNT = 16
 export const VISIBLE_WEEKS_IN_TIMELINE = 3
+/** Only two week buttons stay legible below the sm breakpoint. */
+export const VISIBLE_WEEKS_IN_TIMELINE_MOBILE = 2
+export const TIMELINE_MOBILE_BREAKPOINT = "(min-width: 640px)"
 export const SLIDING_WINDOW_SIZE = 8
+
+/** Scroll-spy line inside the scroll container, measured from its visible top. */
+export const SCROLL_SPY_OFFSET_IN_CONTAINER = 40
+/** Scroll-spy line in the viewport when the page scrolls instead (clears the navbar). */
+export const SCROLL_SPY_OFFSET_IN_VIEWPORT = 140
 
 // Format week range label (e.g. "ÁPR. 20 - 27" or "APR. 28 - MAY 4")
 export const formatWeekRange = (monday: Date, sunday: Date, lang: "hu" | "en") => {

--- a/src/app/(app)/components/events/events.types.ts
+++ b/src/app/(app)/components/events/events.types.ts
@@ -42,4 +42,5 @@ export interface EventsTimelineProps {
   t: Translations
   lang: "hu" | "en"
   totalWeeksCount: number
+  visibleWeeks: number
 }

--- a/src/app/(app)/components/events/useEventsLogic.ts
+++ b/src/app/(app)/components/events/useEventsLogic.ts
@@ -7,7 +7,15 @@ import {
   addDays,
   endOfDay,
 } from "date-fns"
-import { TOTAL_WEEKS_COUNT, SLIDING_WINDOW_SIZE } from "./events.constants"
+import {
+  TOTAL_WEEKS_COUNT,
+  SLIDING_WINDOW_SIZE,
+  SCROLL_SPY_OFFSET_IN_CONTAINER,
+  SCROLL_SPY_OFFSET_IN_VIEWPORT,
+  VISIBLE_WEEKS_IN_TIMELINE,
+  VISIBLE_WEEKS_IN_TIMELINE_MOBILE,
+  TIMELINE_MOBILE_BREAKPOINT,
+} from "./events.constants"
 import { WeekMetadata, Translations } from "./events.types"
 
 interface UseEventsLogicProps {
@@ -66,8 +74,22 @@ export function useEventsLogic({ lang, events, dictionary }: UseEventsLogicProps
     return list
   }, [baseDate, startWeekIndex, totalWeeksCount])
 
-  // Horizontal Timeline Carousel state (shows 3 weeks at a time)
+  // Horizontal Timeline Carousel state (shows 3 weeks at a time, 2 below sm)
   const [timelineStartIdx, setTimelineStartIdx] = useState(0)
+
+  // The timeline renders fewer buttons on narrow screens, so the window size has
+  // to follow suit — otherwise the active week can land on a button that is not
+  // rendered and no pill appears selected.
+  const [visibleWeeks, setVisibleWeeks] = useState(VISIBLE_WEEKS_IN_TIMELINE)
+  useEffect(() => {
+    const query = window.matchMedia(TIMELINE_MOBILE_BREAKPOINT)
+    const sync = () =>
+      setVisibleWeeks(query.matches ? VISIBLE_WEEKS_IN_TIMELINE : VISIBLE_WEEKS_IN_TIMELINE_MOBILE)
+
+    sync()
+    query.addEventListener("change", sync)
+    return () => query.removeEventListener("change", sync)
+  }, [])
   
   // Current active week index highlighted (0 to 7+)
   const [activeWeekIndex, setActiveWeekIndex] = useState(0)
@@ -150,9 +172,8 @@ export function useEventsLogic({ lang, events, dictionary }: UseEventsLogicProps
           })
         } else {
           // Scroll the global window to the week section
-          const headerOffset = 140
           const elementPosition = target.getBoundingClientRect().top
-          const offsetPosition = elementPosition + window.scrollY - headerOffset
+          const offsetPosition = elementPosition + window.scrollY - SCROLL_SPY_OFFSET_IN_VIEWPORT
           
           window.scrollTo({
             top: offsetPosition,
@@ -180,7 +201,7 @@ export function useEventsLogic({ lang, events, dictionary }: UseEventsLogicProps
       }
       setTimelineStartIdx((prev) => prev - 1)
     } else if (direction === "right") {
-      if (timelineStartIdx < startWeekIndex + totalWeeksCount - 3) {
+      if (timelineStartIdx < startWeekIndex + totalWeeksCount - visibleWeeks) {
         // If we are moving right and getting close to the end of the timeline, generate more weeks
         if (timelineStartIdx >= startWeekIndex + totalWeeksCount - 5) {
           setTotalWeeksCount((prev) => prev + 4)
@@ -194,10 +215,12 @@ export function useEventsLogic({ lang, events, dictionary }: UseEventsLogicProps
   useEffect(() => {
     if (activeWeekIndex < timelineStartIdx) {
       setTimelineStartIdx(activeWeekIndex)
-    } else if (activeWeekIndex >= timelineStartIdx + 3) {
-      setTimelineStartIdx(Math.min(startWeekIndex + totalWeeksCount - 3, activeWeekIndex - 2))
+    } else if (activeWeekIndex >= timelineStartIdx + visibleWeeks) {
+      setTimelineStartIdx(
+        Math.min(startWeekIndex + totalWeeksCount - visibleWeeks, activeWeekIndex - (visibleWeeks - 1)),
+      )
     }
-  }, [activeWeekIndex, timelineStartIdx, startWeekIndex, totalWeeksCount])
+  }, [activeWeekIndex, timelineStartIdx, startWeekIndex, totalWeeksCount, visibleWeeks])
 
   // Handle scroll events inside the events container
   const handleScroll = useCallback(() => {
@@ -213,9 +236,13 @@ export function useEventsLogic({ lang, events, dictionary }: UseEventsLogicProps
 
     let bestWeekIdx = -1
     let minDistance = Infinity
-    
-    // Offset target line (e.g. 40px) inside the scroll container
-    const targetScrollTop = container.scrollTop + 40
+
+    // Below md the container has no max-height, so the page scrolls instead of
+    // the container. Express the target line in container coordinates either way,
+    // since offsetTop is measured against the (position: relative) container.
+    const targetScrollTop = container.scrollHeight > container.clientHeight
+      ? container.scrollTop + SCROLL_SPY_OFFSET_IN_CONTAINER
+      : SCROLL_SPY_OFFSET_IN_VIEWPORT - container.getBoundingClientRect().top
 
     for (const { el, index } of elements) {
       if (!el) continue
@@ -274,6 +301,20 @@ export function useEventsLogic({ lang, events, dictionary }: UseEventsLogicProps
     }
   }, [visibleWeeksStartIdx, startWeekIndex, totalWeeksCount])
 
+  // When the container is not scrollable (mobile), its onScroll never fires, so
+  // the page scroll has to drive the scroll-spy and the sliding window instead.
+  useEffect(() => {
+    const onWindowScroll = () => {
+      const container = scrollContainerRef.current
+      if (!container) return
+      if (container.scrollHeight > container.clientHeight) return
+      handleScroll()
+    }
+
+    window.addEventListener("scroll", onWindowScroll, { passive: true })
+    return () => window.removeEventListener("scroll", onWindowScroll)
+  }, [handleScroll])
+
   // Pre-calculate grouped events for the 4 weeks in the sliding window
   const renderedWeekData = useMemo(() => {
     const sliceStart = visibleWeeksStartIdx - startWeekIndex
@@ -289,16 +330,26 @@ export function useEventsLogic({ lang, events, dictionary }: UseEventsLogicProps
     if (!container) return
 
     const diff = visibleWeeksStartIdx - prevStartIdx.current
+    // Mobile scrolls the page, so compensate there instead of on the container.
+    const isContainerScrollable = container.scrollHeight > container.clientHeight
 
     if (diff > 0) {
-      container.scrollTop = Math.max(0, container.scrollTop - lastRemovedHeight.current)
+      if (isContainerScrollable) {
+        container.scrollTop = Math.max(0, container.scrollTop - lastRemovedHeight.current)
+      } else {
+        window.scrollBy(0, -lastRemovedHeight.current)
+      }
     } else if (diff < 0) {
       let addedHeight = 0
       for (let i = visibleWeeksStartIdx; i < prevStartIdx.current; i++) {
         const el = document.getElementById(`week-section-${i}`)
         if (el) addedHeight += el.offsetHeight
       }
-      container.scrollTop = container.scrollTop + addedHeight
+      if (isContainerScrollable) {
+        container.scrollTop = container.scrollTop + addedHeight
+      } else {
+        window.scrollBy(0, addedHeight)
+      }
     }
     prevStartIdx.current = visibleWeeksStartIdx
 
@@ -356,11 +407,15 @@ export function useEventsLogic({ lang, events, dictionary }: UseEventsLogicProps
               const target = document.getElementById(`week-section-${weekIdx}`)
               const container = scrollContainerRef.current
               if (container && target) {
-                const targetOffset = target.offsetTop
-                container.scrollTo({
-                  top: targetOffset,
-                  behavior: "smooth",
-                })
+                if (container.scrollHeight > container.clientHeight) {
+                  container.scrollTo({ top: target.offsetTop, behavior: "smooth" })
+                } else {
+                  // Mobile: the page scrolls, not the container.
+                  window.scrollTo({
+                    top: target.getBoundingClientRect().top + window.scrollY - SCROLL_SPY_OFFSET_IN_VIEWPORT,
+                    behavior: "smooth",
+                  })
+                }
               }
             }, 300)
           }
@@ -404,5 +459,6 @@ export function useEventsLogic({ lang, events, dictionary }: UseEventsLogicProps
     handleShare,
     handleScroll,
     totalWeeksCount,
+    visibleWeeks,
   }
 }

--- a/src/app/(app)/components/navbar/navbar.constants.ts
+++ b/src/app/(app)/components/navbar/navbar.constants.ts
@@ -20,19 +20,19 @@ export const NAVBAR_STYLES = {
   },
   
   mobile: {
-    trigger: 'xlg:hidden text-white hover:text-gray-200 transition-colors duration-200',
+    trigger: 'xlg:hidden size-11 text-white hover:text-gray-200 transition-colors duration-200',
     sheet: 'w-80 px-0 py-0 sm:px-2 sm:py-2',
     container: 'flex h-full flex-col min-h-0',
     header: 'px-4 py-4 border-b',
     nav: 'space-y-4 p-4 pt-2 pb-6',
     menuItem: 'font-semibold text-gray-900 text-base border-b-2 border-gray-200 pb-2 block hover:text-ehk-navbar hover:border-ehk-navbar transition-all duration-200',
-    subItemsContainer: 'space-y-1 pl-4',
-    subMenuItem: 'block text-sm text-gray-600 hover:text-ehk-navbar py-1.5 transition-all duration-200 hover:pl-2 font-medium'
+    subItemsContainer: 'pl-4',
+    subMenuItem: 'flex min-h-11 items-center text-sm text-gray-600 hover:text-ehk-navbar py-2.5 transition-all duration-200 hover:pl-2 font-medium'
   },
   
   actions: {
     container: 'flex items-center space-x-2 ml-2',
-    langToggle: 'bg-transparent text-white hover:bg-white/10 px-2.5 py-[5px] border-[0.5px] border-[#f9f4f0] rounded-[10px] font-semibold text-sm transition-all duration-200',
+    langToggle: 'inline-flex min-h-11 min-w-11 items-center justify-center bg-transparent text-white hover:bg-white/10 px-3 py-2 border-[0.5px] border-[#f9f4f0] rounded-[10px] font-semibold text-sm transition-all duration-200',
     searchButton: 'text-white hover:text-gray-200 transition-colors duration-200'
   }
 } as const

--- a/src/components/common/ContactBubble.tsx
+++ b/src/components/common/ContactBubble.tsx
@@ -9,14 +9,14 @@ export const ContactBubble = () => {
   return (
     <a
       href="mailto:info@bmeehk.hu"
-      className="fixed bottom-6 right-6 z-50 flex items-center gap-2 bg-[#862633] text-white px-4 py-3 rounded-full shadow-lg hover:bg-[#6b1e28] transition-all hover:scale-105 group"
+      className="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center gap-2 bg-[#862633] text-white rounded-full shadow-lg hover:bg-[#6b1e28] transition-all hover:scale-105 group md:h-auto md:w-auto md:px-4 md:py-3"
       aria-label={t('common.contact_aria_label')}
     >
       <div className="relative">
         <Mail className="w-5 h-5" />
         <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 border-2 border-[#862633] rounded-full animate-pulse"></span>
       </div>
-      <span className="font-medium">{t('common.questions')}</span>
+      <span className="hidden md:inline font-medium">{t('common.questions')}</span>
     </a>
   )
 }

--- a/src/components/common/OrganizationCard.tsx
+++ b/src/components/common/OrganizationCard.tsx
@@ -49,6 +49,18 @@ export function OrganizationCard({
       )
     : [];
 
+  // Every section renders null when its input is missing, so without this the
+  // mobile card would show a "Részletek" trigger that opens onto nothing.
+  const hasDetails = Boolean(
+    presentation ||
+      events?.length ||
+      activities?.length ||
+      departments?.length ||
+      targetAudience ||
+      sortedSocialLinks.length ||
+      galleryImages?.length,
+  );
+
   const sections = (
     <>
       <PresentationSection
@@ -89,18 +101,22 @@ export function OrganizationCard({
     >
       <OrganizationCardHeader name={name} stats={stats} />
 
-      {/* Fully expanded these cards run ~1300px each, which turns a listing page
-          into tens of screens on a phone. Collapse them below md. */}
-      <AccordionItem
-        className="rounded-none border-0 md:hidden"
-        buttonClassName="px-4 py-3"
-        contentClassName="space-y-4 px-4 pb-4"
-        title={sectionLabels.details}
-      >
-        {sections}
-      </AccordionItem>
+      {hasDetails && (
+        <>
+          {/* Fully expanded these cards run ~1300px each, which turns a listing
+              page into tens of screens on a phone. Collapse them below md. */}
+          <AccordionItem
+            className="rounded-none border-0 md:hidden"
+            buttonClassName="px-4 py-3"
+            contentClassName="space-y-4 px-4 pb-4"
+            title={sectionLabels.details}
+          >
+            {sections}
+          </AccordionItem>
 
-      <div className="hidden space-y-4 p-4 md:block">{sections}</div>
+          <div className="hidden space-y-4 p-4 md:block">{sections}</div>
+        </>
+      )}
 
       <JoinCta href={joinUrl} prompt={joinPrompt}>
         {joinText ?? sectionLabels.join}

--- a/src/components/common/OrganizationCard.tsx
+++ b/src/components/common/OrganizationCard.tsx
@@ -9,6 +9,7 @@ import {
   PresentationSection,
   RichTextSection,
 } from "@/components/common/organization-card/sections";
+import { AccordionItem } from "@/components/common/Accordion";
 import type { OrganizationCardProps } from "@/components/common/organization-card/types";
 import { getOrganizationCardLabels } from "@/components/common/organization-card/utils";
 import { getSocialPriority } from "@/lib/social-utils";
@@ -48,6 +49,37 @@ export function OrganizationCard({
       )
     : [];
 
+  const sections = (
+    <>
+      <PresentationSection
+        title={sectionLabels.presentation}
+        content={presentation}
+      />
+      <EventsSection title={sectionLabels.events} events={events} />
+      <InlineListSection title={sectionLabels.activities} items={activities} />
+      <DepartmentsSection
+        title={sectionLabels.departments}
+        departments={departments}
+      />
+      <RichTextSection
+        title={sectionLabels.targetAudience}
+        content={targetAudience}
+      />
+      <ContactsSection
+        title={sectionLabels.contacts}
+        links={sortedSocialLinks}
+        locale={locale}
+      />
+      <GallerySection
+        title={sectionLabels.gallery}
+        images={galleryImages}
+        imageBasePath={imageBasePath}
+        organizationName={name}
+        locale={locale}
+      />
+    </>
+  );
+
   return (
     <article
       className={cn(
@@ -57,37 +89,18 @@ export function OrganizationCard({
     >
       <OrganizationCardHeader name={name} stats={stats} />
 
-      <div className="space-y-4 p-4">
-        <PresentationSection
-          title={sectionLabels.presentation}
-          content={presentation}
-        />
-        <EventsSection title={sectionLabels.events} events={events} />
-        <InlineListSection
-          title={sectionLabels.activities}
-          items={activities}
-        />
-        <DepartmentsSection
-          title={sectionLabels.departments}
-          departments={departments}
-        />
-        <RichTextSection
-          title={sectionLabels.targetAudience}
-          content={targetAudience}
-        />
-        <ContactsSection
-          title={sectionLabels.contacts}
-          links={sortedSocialLinks}
-          locale={locale}
-        />
-        <GallerySection
-          title={sectionLabels.gallery}
-          images={galleryImages}
-          imageBasePath={imageBasePath}
-          organizationName={name}
-          locale={locale}
-        />
-      </div>
+      {/* Fully expanded these cards run ~1300px each, which turns a listing page
+          into tens of screens on a phone. Collapse them below md. */}
+      <AccordionItem
+        className="rounded-none border-0 md:hidden"
+        buttonClassName="px-4 py-3"
+        contentClassName="space-y-4 px-4 pb-4"
+        title={sectionLabels.details}
+      >
+        {sections}
+      </AccordionItem>
+
+      <div className="hidden space-y-4 p-4 md:block">{sections}</div>
 
       <JoinCta href={joinUrl} prompt={joinPrompt}>
         {joinText ?? sectionLabels.join}

--- a/src/components/common/PageBlock.tsx
+++ b/src/components/common/PageBlock.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 
 function PostBlock({ className, ...props }: React.ComponentProps<"div">) {
     return (
-        <div className="container mx-auto">
+        <div className="container mx-auto px-4 md:px-6">
             <Card className="hover:shadow-md transition-all duration-300">
                 <CardContent className="p-3 md:p-6">
                     <div className={cn("flex flex-col gap-2 md:gap-3", className)}

--- a/src/components/common/organization-card/types.ts
+++ b/src/components/common/organization-card/types.ts
@@ -38,6 +38,8 @@ export type OrganizationCardLabels = {
   contacts: string;
   gallery: string;
   join: string;
+  /** Trigger of the mobile-only accordion that collapses every section. */
+  details: string;
 };
 
 export type OrganizationCardProps = {

--- a/src/components/common/organization-card/utils.tsx
+++ b/src/components/common/organization-card/utils.tsx
@@ -19,6 +19,7 @@ const labelsByLocale: Record<Locale, OrganizationCardLabels> = {
     contacts: "Elérhetőségek",
     gallery: "Galéria",
     join: "Csatlakozom!",
+    details: "Részletek",
   },
   en: {
     presentation: "Presentation",
@@ -29,6 +30,7 @@ const labelsByLocale: Record<Locale, OrganizationCardLabels> = {
     contacts: "Contact",
     gallery: "Gallery",
     join: "Join us",
+    details: "Details",
   },
 };
 

--- a/src/components/news/NewsCard.tsx
+++ b/src/components/news/NewsCard.tsx
@@ -39,7 +39,7 @@ export default function NewsCard({ news: { id, title, titleEng, shortDescription
                         : `/${lang.toLowerCase()}?tab=news`
 
                     const chipClass = cn(
-                        "inline-flex items-center justify-center px-2.5 py-1 rounded-full text-sm font-open-sans font-normal whitespace-nowrap transition-colors duration-200 border",
+                        "inline-flex min-h-11 items-center justify-center px-3 py-2 rounded-full text-sm font-open-sans font-normal whitespace-nowrap transition-colors duration-200 border",
                         isActive
                             ? "bg-[#ffe6e6] text-[#862633] border-[#862633] hover:bg-[#ffe6e6]/80"
                             : "bg-transparent text-[#3d3d3d] border-[#3d3d3d] hover:bg-[#3d3d3d]/5"
@@ -73,7 +73,7 @@ export default function NewsCard({ news: { id, title, titleEng, shortDescription
 
                 {/* Title */}
                 <h3 className="font-playfair font-bold text-[22px] leading-[1.3] text-black w-full group-hover:text-[#862633] transition-colors duration-200">
-                    <Link href={newsUrl}>
+                    <Link href={newsUrl} className="flex min-h-11 items-center">
                         {displayTitle}
                     </Link>
                 </h3>
@@ -90,7 +90,7 @@ export default function NewsCard({ news: { id, title, titleEng, shortDescription
             {/* Footer read more */}
             <Link
                 href={newsUrl}
-                className="flex items-center justify-between w-full group/link"
+                className="flex min-h-11 items-center justify-between w-full group/link"
             >
                 <span className="font-open-sans font-semibold text-[14px] leading-[1.6] text-[#862633] whitespace-nowrap">
                     {t('news.read_more', 'Elolvasom')}

--- a/src/components/news/NewsPagination.tsx
+++ b/src/components/news/NewsPagination.tsx
@@ -95,7 +95,7 @@ export default function NewsPagination({ currentPage, totalPages, basePath = "/"
 
   if (totalPages <= 1) return null;
 
-  const btnBase = "w-9 h-9 flex items-center justify-center rounded-lg border text-sm transition-colors duration-200 shadow-sm";
+  const btnBase = "w-11 h-11 flex items-center justify-center rounded-lg border text-sm transition-colors duration-200 shadow-sm";
 
   if (onPageChange) {
     return (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[200] bg-black/50",
         className
       )}
       {...props}
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[200] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-2 right-2 flex h-11 w-11 items-center justify-center rounded-md opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[200] bg-black/50",
         className
       )}
       {...props}
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-[200] flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&
@@ -72,8 +72,8 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-2 right-2 flex h-11 w-11 items-center justify-center rounded-md opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-5" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>


### PR DESCRIPTION
## Mit csinál

Kijavítja a mobil UI audit során talált összes hibát. Az auditot 49 útvonalon (35 HU + 14 EN) futtattam 375×812-n és 320×720-on, valós kliensoldali navigációval, elemenkénti geometria-méréssel.

## Kritikus

**Az overlay-ek a navbar alá kerültek.** A navbar `relative z-[100]`, a Radix Sheet/Dialog `z-50` — a header ráfestett minden drawer és modál felső 81 pixelére. Mobilon ez teljesen eltakarta a menü címét és a bezáró gombot (ami ráadásul 16×16 volt), így a menü csak az overlay-re koppintva volt zárható.
→ Overlay és content `z-[200]`, bezáró gomb 44×44.

**A footernek nem volt vízszintes paddingje.** A Tailwind v4-ben a `container` utility elvesztette a beépített oldalpaddingot, így a `container mx-auto` 0px-re oldódott fel — minden footer-oszlop a képernyő szélére tapadt. Ugyanez a `PageBlock`-ban is.
→ `px-4 md:px-6`.

**A lebegő kapcsolat-gomb takarta a tartalmat.** 168×48-as fix elemként letakarta a Neptun linket a sidebarban, a hírkártyák „Elolvasom" linkjeit és az international oldalak törzsszövegét.
→ Mobilon 56×56 ikon, felirat csak `md`-től.

## Súlyos

**Hero csík 113px magas volt.** Az `aspect-10/3` széles képernyőre van hangolva; 375px-en 113px lett belőle, és a kezdőlap `-mt-16`-tal ráhúzta a tartalmat, így a fotóból ~81px látszott, a pöttyök pedig egyáltalán nem.
→ `16/9 → 21/9 → 10/3` lépcső, és nincs negatív margó `lg` alatt. Mobilon most 211px.

**A hét-választó levágta a dátumot.** Három pill osztozott a soron minden szélességen, így 375px-en egyenként 55px jutott: a „JÖVŐ HÉT / AUG. 10 – 16" 49px-re tört egy fix `h-10` dobozban, a slider `overflow-hidden`-je pedig félbevágta.
→ Növekedhet a pill, `sm` alatt csak két hét látszik. Emellett a napi lista 650px-es `max-height`-ja is feloldva mobilon, hogy ne csapdázza a görgetést.

**Végtelen listaoldalak.** Az `OrganizationCard` minden szekciót kibontva renderelt: a szakkollégiumok oldal 21 369px volt (26 képernyő), 15 kártyával, átlag 1273px-szel.
→ A szekciók a meglévő `AccordionItem`-be kerülnek `md` alatt; a desktop változatlan.

## Akadálymentesítés

Mind a 34 mobil menüpont 32px magas volt, a nyelvváltó 41×31, a lapozógombok 36×36, a karusszel-pöttyök 12×12. A kapcsolódó hírek címkéi 8px-en jelentek meg.
→ Interaktív elemek 44px minimumra, a legkisebb feliratok 11px-re. A mondatba ágyazott linkeket meghagytam — átméretezésük megtörné a sortávot, és a WCAG 2.5.8 kifejezetten kiveszi őket.

## Mérési eredmények

| | előtte | utána |
|---|---|---|
| Szakkollégiumok oldal | 21 369px | **4 182px** |
| Öntevékeny körök | 13 784px | **4 044px** |
| Versenycsapatok | 11 998px | **2 931px** |
| Footer magasság | 1 463px (1,80×) | **1 263px (1,55×)** |
| Hero magasság | 113px | **211px** |
| 44px alatti mobil menüpont | 34 | **0** |
| 11px alatti szöveg | 8px címkék | **nincs** |

## Ellenőrzés

- `tsc --noEmit`, `yarn lint`, `yarn build` — mind tiszta (a meglévő `<img>` warning érintetlen).
- Újramérve mind a 49 útvonalon 375px-en és 320px-en: nincs vízszintes túlcsordulás, nincs levágás, nincs 11px alatti szöveg.
- Desktop (1280px) külön ellenőrizve: az akkordeon rejtve, a kibontott szekciók láthatók, a hero és a `-mt-24` átfedés változatlan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layouts across navigation, footer, page content, organization cards, and event timelines.
  * Increased touch-target sizes and spacing for buttons, links, filters, news cards, pagination, contact actions, and widgets.
  * Enhanced image viewer responsiveness, navigation controls, and indicator scrolling.
  * Added collapsible organization details on smaller screens.
  * Refined dialog and side-panel close controls.
  * Adjusted mobile contact bubble, language toggle, submenu items, typography, padding, and card layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->